### PR TITLE
Alternative API 2 - use special SuperInvoker callback

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/InvocationHandler.java
+++ b/src/java.base/share/classes/java/lang/reflect/InvocationHandler.java
@@ -25,19 +25,6 @@
 
 package java.lang.reflect;
 
-import jdk.internal.reflect.CallerSensitive;
-import jdk.internal.reflect.Reflection;
-
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
-import java.lang.invoke.WrongMethodTypeException;
-import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.BooleanSupplier;
-
-import static java.lang.invoke.MethodType.methodType;
-
 /**
  * {@code InvocationHandler} is the interface implemented by
  * the <i>invocation handler</i> of a proxy instance.
@@ -49,15 +36,19 @@ import static java.lang.invoke.MethodType.methodType;
  *
  * @author      Peter Jones
  * @see         Proxy
+ * @see         InvocationHandler2
  * @since       1.3
  */
-public interface InvocationHandler {
+@FunctionalInterface
+public interface InvocationHandler extends InvocationHandler2 {
 
     /**
      * Processes a method invocation on a proxy instance and returns
      * the result.  This method will be invoked on an invocation handler
      * when a method is invoked on a proxy instance that it is
-     * associated with.
+     * associated with unless
+     * {@linkplain #invoke(SuperInvoker, Object, Method, Object[])}
+     * method is overridden.
      *
      * @param   proxy the proxy instance that the method was invoked on
      *
@@ -102,231 +93,26 @@ public interface InvocationHandler {
      * method invocation on the proxy instance.
      *
      * @see     UndeclaredThrowableException
+     * @see     InvocationHandler#invoke(SuperInvoker, Object, Method, Object[])
      */
     public Object invoke(Object proxy, Method method, Object[] args)
         throws Throwable;
 
     /**
-     * Invokes the specified default method on the given {@code proxy} instance with
-     * the given parameters.  The given {@code method} must be a default method
-     * declared in a proxy interface of the {@code proxy}'s class or inherited
-     * from its superinterface directly or indirectly.
-     * <p>
-     * This method behaves as if called from an {@code invokespecial} instruction
-     * from the proxy class as the caller equivalent to the invocation of
-     * {@code X.super.m(A* a)} where {@code X} is a proxy interface and
-     * the call to {@code X.super::m(A*)} is resolved to the given {@code method}.
-     * <p>
-     * For example, interface {@code A} and {@code B} both declare a default
-     * implementation of method {@code m}. Interface {@code C} extends {@code A}
-     * and it inherits the default method {@code m} from its superinterface {@code A}.
+     * Processes a method invocation on a proxy instance and returns the result.
+     * This method just delegates to
+     * {@linkplain #invoke(Object, Method, Object[])}, ignoring the {@code superInvoker}
+     * parameter.
+     * You should not override this method if you want to create proxies for
+     * interfaces that are not accessible to code creating proxy instances.
      *
-     * <blockquote><pre>{@code
-     * interface A {
-     *     default T m(A a) { return t1; }
-     * }
-     * interface B {
-     *     default T m(A a) { return t2; }
-     * }
-     * interface C extends A {}
-     * }</pre></blockquote>
-     *
-     * The following creates a proxy instance that implements {@code A}
-     * and invokes the default method {@code A::m}.
-     *
-     * <blockquote><pre>{@code
-     * Object proxy = Proxy.newProxyInstance(loader, new Class<?>[] { A.class },
-     *         (o, m, params) -> {
-     *             assert m.getDeclaringClass() == A.class && m.isDefault();
-     *             return InvocationHandler.invokeDefaultMethod(o, m, params);
-     *         });
-     * }</pre></blockquote>
-     *
-     * If a proxy instance implements both {@code A} and {@code B}, both
-     * of which provides the default implementation of method {@code m},
-     * the invocation handler can dispatch the method invocation to
-     * {@code A::m} or {@code B::m} via the {@code invokeDefaultMethod} method.
-     * For example, the following code delegates the method invocation
-     * to {@code B::m}.
-     *
-     * <blockquote><pre>{@code
-     * Object proxy = Proxy.newProxyInstance(loader, new Class<?>[] { A.class, B.class },
-     *         (o, m, params) -> {
-     *             // delegate to invoking B::m
-     *             Method selectedMethod = B.class.getMethod(m.getName(), m.getParameterTypes());
-     *             return InvocationHandler.invokeDefaultMethod(o, selectedMethod, params);
-     *         });
-     * }</pre></blockquote>
-     *
-     * If a proxy instance implements {@code C} that inherits the default
-     * method {@code m} from its superinterface {@code A}, then
-     * the interface method invocation on {@code "m"} is dispatched to
-     * the invocation handler's {@link #invoke(Object, Method, Object[]) invoke}
-     * method with the {@code Method} object argument representing the
-     * default method {@code A::m}.
-     *
-     * <blockquote><pre>{@code
-     * Object c = Proxy.newProxyInstance(loader, new Class<?>[] { C.class },
-     *        (o, m, params) -> {
-     *             assert m.isDefault();
-     *             return InvocationHandler.invokeDefaultMethod(o, m, params);
-     *        });
-     * }</pre></blockquote>
-     *
-     * The invocation of method {@code "m"} on {@code c} will behave as if
-     * {@code C.super::m} is called and that is resolved to invoking
-     * {@code A::m}.
-     * <p>
-     * If {@code C} is modified to override {@code m} as below:
-     *
-     * <blockquote><pre>{@code
-     * interface C extends A {
-     *     default T m(A a) { return t3; }
-     * }
-     * }</pre></blockquote>
-     *
-     * {@code C.super::m} will be resolved to {@code C::m} instead.
-     * The invocation of method {@code "m"} on {@code c} will behave
-     * differently and result in invoking {@code C::m} instead of {@code A::m}.
-     * <p>
-     * If an invocation handler dispatches the method invocation by calling
-     * the {@code invokeDefaultMethod} method with the {@code Method} object
-     * representing {@code A::m}:
-     *
-     * <blockquote><pre>{@code
-     * Object proxy = Proxy.newProxyInstance(loader, new Class<?>[] { C.class },
-     *         (o, m, params) -> {
-     *             // IllegalArgumentException thrown as {@code A::m} is not a method
-     *             // inherited from its proxy interface C
-     *             return InvocationHandler.invokeDefaultMethod(o, A.class.getMethod("m"), params);
-     *         });
-     * }</pre></blockquote>
-     *
-     * The invocation on {@code "m"} with this proxy instance will result in
-     * an {@code IllegalArgumentException} because {@code C} overrides the implementation
-     * of the same method and {@code A::m} is not accessible by a proxy instance.
-     *
-     * @param proxy   the {@code Proxy} instance on which the default method to be invoked
-     * @param method  the {@code Method} instance corresponding to a default method
-     *                declared in a proxy interface of the proxy class or inherited
-     *                from its superinterface directly or indirectly
-     * @param args    the parameters used for the method invocation; can be {@code null}
-     *                if the number of formal parameters required by the method is zero.
-     * @return the value returned from the method invocation
-     *
-     * @throws IllegalArgumentException if any of the following conditions is {@code true}:
-     *         <ul>
-     *         <li>{@code proxy} is not {@linkplain Proxy#isProxyClass(Class)
-     *             a proxy instance}; or</li>
-     *         <li>the given {@code method} is not a default method declared
-     *             in a proxy interface of the proxy class and not inherited from
-     *             any of its superinterfaces; or</li>
-     *         <li>the given {@code method} is overridden directly or indirectly by
-     *             the proxy interfaces and the method reference to the named
-     *             method never resolves to the given {@code method}; or</li>
-     *         <li>the length of the given {@code args} array does not match the
-     *             number of parameters of the method to be invoked; or</li>
-     *         <li>any of the {@code args} elements fails the unboxing
-     *             conversion if the corresponding method parameter type is
-     *             a primitive type; or if, after possible unboxing, any of the
-     *             {@code args} elements cannot be assigned to the corresponding
-     *             method parameter type.</li>
-     *         </ul>
-     * @throws IllegalAccessException if the declaring class of the specified
-     *         default method is inaccessible to the caller class
-     * @throws InvocationTargetException if the invoked default method throws
-     *         any exception, it is wrapped by {@code InvocationTargetException}
-     *         and rethrown
-     * @throws NullPointerException if {@code proxy} or {@code method} is {@code null}
-     *
+     * @see #invoke(Object, Method, Object[])
      * @since 16
-     * @jvms 5.4.3. Method Resolution
      */
-    @CallerSensitive
-    public static Object invokeDefaultMethod(Object proxy, Method method, Object... args)
-            throws IllegalAccessException, InvocationTargetException {
-        Objects.requireNonNull(proxy);
-        Objects.requireNonNull(method);
-
-        // verify that the object is actually a proxy instance
-        Class<?> proxyClass = proxy.getClass();
-        if (!Proxy.isProxyClass(proxyClass)) {
-            throw new IllegalArgumentException("'proxy' is not a proxy instance");
-        }
-        if (!method.isDefault()) {
-            throw new IllegalArgumentException("\"" + method + "\" is not a default method");
-        }
-        Class<?> intf = method.getDeclaringClass();
-        // access check if it is a non-public proxy interface or not unconditionally exported
-        if (!Modifier.isPublic(intf.getModifiers()) ||
-                !intf.getModule().isExported(intf.getPackageName())) {
-            // throw IAE if the caller class has no access to the default method
-            // same access check to Method::invoke on the default method
-            int modifiers = method.getModifiers();
-            Class<?> caller = Reflection.getCallerClass();
-            method.checkAccess(caller, intf, proxyClass, modifiers);
-        }
-
-        // lookup the cached method handle
-        ConcurrentHashMap<Method, MethodHandle> methods = Proxy.defaultMethodMap(proxyClass);
-        MethodHandle superMH = methods.get(method);
-
-        if (superMH == null) {
-            MethodType type = methodType(method.getReturnType(), method.getParameterTypes());
-            MethodHandles.Lookup lookup = MethodHandles.lookup();
-            Class<?> proxyInterface = Proxy.findProxyInterfaceOrElseThrow(proxyClass, method);
-            MethodHandle dmh;
-            try {
-                dmh = Proxy.proxyClassLookup(lookup, proxyClass)
-                           .findSpecial(proxyInterface, method.getName(), type, proxyClass)
-                           .withVarargs(false);
-            } catch (IllegalAccessException | NoSuchMethodException e) {
-                // should not reach here
-                throw new InternalError(e);
-            }
-            // this check can be turned into assertion as it is guaranteed to succeed by the virtue of
-            // looking up a default (instance) method declared or inherited by proxyInterface
-            // while proxyClass implements (is a subtype of) proxyInterface ...
-            assert ((BooleanSupplier) () -> {
-                try {
-                    // make sure that the method type matches
-                    dmh.asType(type.insertParameterTypes(0, proxyClass));
-                    return true;
-                } catch (WrongMethodTypeException e) {
-                    return false;
-                }
-            }).getAsBoolean() : "Wrong method type";
-            // change return type to Object
-            MethodHandle mh = dmh.asType(dmh.type().changeReturnType(Object.class));
-            // wrap any exception thrown with InvocationTargetException
-            mh = MethodHandles.catchException(mh, Throwable.class, Proxy.wrapWithInvocationTargetExceptionMH());
-            // spread array of arguments among parameters (skipping 1st parameter - target)
-            mh = mh.asSpreader(1, Object[].class, type.parameterCount());
-            // change target type to Object
-            mh = mh.asType(MethodType.methodType(Object.class, Object.class, Object[].class));
-
-            // push MH into cache
-            MethodHandle cached = methods.putIfAbsent(method, mh);
-            if (cached != null) {
-                superMH = cached;
-            } else {
-                superMH = mh;
-            }
-        }
-
-        // invoke the super method
-        try {
-            // the args array can be null if the number of formal parameters required by
-            // the method is zero (consistent with Method::invoke)
-            Object[] params = args != null ? args : Proxy.EMPTY_ARGS;
-            return superMH.invokeExact(proxy, params);
-        } catch (ClassCastException | NullPointerException e) {
-            throw new IllegalArgumentException(e.getMessage(), e);
-        } catch (InvocationTargetException | RuntimeException | Error e) {
-            throw e;
-        } catch (Throwable e) {
-            // should not reach here
-            throw new InternalError(e);
-        }
+    @Override
+    default Object invoke(SuperInvoker superInvoker, Object proxy, Method method, Object[] args)
+        throws Throwable
+    {
+        return invoke(proxy, method, args);
     }
 }

--- a/src/java.base/share/classes/java/lang/reflect/InvocationHandler2.java
+++ b/src/java.base/share/classes/java/lang/reflect/InvocationHandler2.java
@@ -1,0 +1,219 @@
+package java.lang.reflect;
+
+/**
+ * {@code InvocationHandler2} is a functional super-interface of plain
+ * {@linkplain InvocationHandler}. It is invoked with additional {@code superInvoker}
+ * parameter needed to invoke super default methods of proxy interfaces via
+ * {@linkplain SuperInvoker#invokeSuper(Object, Method, Object...)}.
+ * If you don't need to invoke super default methods of proxy interfaces, you can implement
+ * plain {@linkplain InvocationHandler} which doesn't receive the {@code superInvoker}
+ * parameter and can be used as a handler even for proxies implementing interfaces
+ * inaccessible to code creating such proxies.
+ * Invocation handlers directly implementing this interface may only be used as
+ * handlers for proxies implementing interfaces accessible to code creating such
+ * proxies via
+ * {@linkplain Proxy#newProxyInstance(ClassLoader, Class[], InvocationHandler2)}.
+ *
+ * @see InvocationHandler
+ * @since 16
+ */
+@FunctionalInterface
+public interface InvocationHandler2 {
+
+    /**
+     * Processes a method invocation on a proxy instance and returns
+     * the result.  This method will be invoked on an invocation handler
+     * when a method is invoked on a proxy instance that it is
+     * associated with.
+     *
+     * @param superInvoker the call-back that enables calling super default
+     *                     methods on the proxy interfaces via
+     *                     {@linkplain SuperInvoker#invokeSuper(Object, Method, Object...)}
+     * @param proxy        the proxy instance that the method was invoked on
+     * @param method       the {@code Method} instance corresponding to
+     *                     the interface method invoked on the proxy instance.  The declaring
+     *                     class of the {@code Method} object will be the interface that
+     *                     the method was declared in, which may be a superinterface of the
+     *                     proxy interface that the proxy class inherits the method through.
+     * @param args         an array of objects containing the values of the
+     *                     arguments passed in the method invocation on the proxy instance,
+     *                     or {@code null} if interface method takes no arguments.
+     *                     Arguments of primitive types are wrapped in instances of the
+     *                     appropriate primitive wrapper class, such as
+     *                     {@code java.lang.Integer} or {@code java.lang.Boolean}.
+     * @return the value to return from the method invocation on the
+     * proxy instance.  If the declared return type of the interface
+     * method is a primitive type, then the value returned by
+     * this method must be an instance of the corresponding primitive
+     * wrapper class; otherwise, it must be a type assignable to the
+     * declared return type.  If the value returned by this method is
+     * {@code null} and the interface method's return type is
+     * primitive, then a {@code NullPointerException} will be
+     * thrown by the method invocation on the proxy instance.  If the
+     * value returned by this method is otherwise not compatible with
+     * the interface method's declared return type as described above,
+     * a {@code ClassCastException} will be thrown by the method
+     * invocation on the proxy instance.
+     * @throws Throwable the exception to throw from the method
+     *                   invocation on the proxy instance.  The exception's type must be
+     *                   assignable either to any of the exception types declared in the
+     *                   {@code throws} clause of the interface method or to the
+     *                   unchecked exception types {@code java.lang.RuntimeException}
+     *                   or {@code java.lang.Error}.  If a checked exception is
+     *                   thrown by this method that is not assignable to any of the
+     *                   exception types declared in the {@code throws} clause of
+     *                   the interface method, then an
+     *                   {@link UndeclaredThrowableException} containing the
+     *                   exception that was thrown by this method will be thrown by the
+     *                   method invocation on the proxy instance.
+     * @see UndeclaredThrowableException
+     * @see InvocationHandler#invoke(Object, Method, Object[])
+     */
+    Object invoke(SuperInvoker superInvoker, Object proxy, Method method, Object[] args) throws Throwable;
+
+    /**
+     * A call-back interface passed as 1st parameter to
+     * {@linkplain InvocationHandler2#invoke(SuperInvoker, Object, Method, Object[])}
+     * enables the invocation handler to invoke super default methods on interfaces
+     * implemented by proxy classes.
+     *
+     * @see #invokeSuper(Object, Method, Object[])
+     * @since 16
+     */
+    interface SuperInvoker {
+
+        /**
+         * Invokes the specified super default method on the given {@code proxy} instance
+         * with the given parameters.  The given {@code method} must be a default method
+         * declared in a proxy interface of the {@code proxy}'s class or inherited
+         * from its superinterface directly or indirectly.
+         * <p>
+         * This method behaves as if called from an {@code invokespecial} instruction
+         * from the proxy class as the caller equivalent to the invocation of
+         * {@code X.super.m(A* a)} where {@code X} is a proxy interface and
+         * the call to {@code X.super::m(A*)} is resolved to the given {@code method}.
+         * <p>
+         * For example, interface {@code A} and {@code B} both declare a default
+         * implementation of method {@code m}. Interface {@code C} extends {@code A}
+         * and it inherits the default method {@code m} from its superinterface {@code A}.
+         *
+         * <blockquote><pre>{@code
+         * interface A {
+         *     default T m(A a) { return t1; }
+         * }
+         * interface B {
+         *     default T m(A a) { return t2; }
+         * }
+         * interface C extends A {}
+         * }</pre></blockquote>
+         * <p>
+         * The following creates a proxy instance that implements {@code A}
+         * and invokes the default method {@code A::m}.
+         *
+         * <blockquote><pre>{@code
+         * Object proxy = Proxy.newProxyInstance(loader, new Class<?>[] { A.class },
+         *         (invoker, o, m, params) -> {
+         *             assert m.getDeclaringClass() == A.class && m.isDefault();
+         *             return invoker.invokeSuper(o, m, params);
+         *         });
+         * }</pre></blockquote>
+         * <p>
+         * If a proxy instance implements both {@code A} and {@code B}, both
+         * of which provides the default implementation of method {@code m},
+         * the invocation handler can dispatch the method invocation to
+         * {@code A::m} or {@code B::m} via the {@code invokeSuper}.
+         * For example, the following code delegates the method invocation
+         * to {@code B::m}.
+         *
+         * <blockquote><pre>{@code
+         * Object proxy = Proxy.newProxyInstance(loader, new Class<?>[] { A.class, B.class },
+         *         (invoker, o, m, params) -> {
+         *             // delegate to invoking B::m
+         *             Method selectedMethod = B.class.getMethod(m.getName(), m.getParameterTypes());
+         *             return invoker.invokeSuper(o, selectedMethod, params);
+         *         });
+         * }</pre></blockquote>
+         * <p>
+         * If a proxy instance implements {@code C} that inherits the default
+         * method {@code m} from its superinterface {@code A}, then
+         * the interface method invocation on {@code "m"} is dispatched to
+         * the invocation handler's {@link #invoke(SuperInvoker, Object, Method, Object[]) invoke}
+         * method with the {@code Method} object argument representing the
+         * default method {@code A::m}.
+         *
+         * <blockquote><pre>{@code
+         * Object c = Proxy.newProxyInstance(loader, new Class<?>[] { C.class },
+         *        (invoker, o, m, params) -> {
+         *             assert m.isDefault();
+         *             return invoker.invokeSuper(o, m, params);
+         *        });
+         * }</pre></blockquote>
+         * <p>
+         * The invocation of method {@code "m"} on {@code c} will behave as if
+         * {@code C.super::m} is called and that is resolved to invoking
+         * {@code A::m}.
+         * <p>
+         * If {@code C} is modified to override {@code m} as below:
+         *
+         * <blockquote><pre>{@code
+         * interface C extends A {
+         *     default T m(A a) { return t3; }
+         * }
+         * }</pre></blockquote>
+         * <p>
+         * {@code C.super::m} will be resolved to {@code C::m} instead.
+         * The invocation of method {@code "m"} on {@code c} will behave
+         * differently and result in invoking {@code C::m} instead of {@code A::m}.
+         * <p>
+         * If an invocation handler dispatches the method invocation by calling
+         * the {@code invokeSuper} method with the {@code Method} object
+         * representing {@code A::m}:
+         *
+         * <blockquote><pre>{@code
+         * Object proxy = Proxy.newProxyInstance(loader, new Class<?>[] { C.class },
+         *         (invoker, o, m, params) -> {
+         *             // IllegalArgumentException thrown as {@code A::m} is not a method
+         *             // inherited from its proxy interface C
+         *             return invoker.invokeSuper(o, A.class.getMethod("m"), params);
+         *         });
+         * }</pre></blockquote>
+         * <p>
+         * The invocation on {@code "m"} with this proxy instance will result in
+         * an {@code IllegalArgumentException} because {@code C} overrides the implementation
+         * of the same method and {@code A::m} is not accessible by a proxy instance.
+         *
+         * @param proxy  the {@code Proxy} instance on which the default method to be invoked
+         * @param method the {@code Method} instance corresponding to a default method
+         *               declared in a proxy interface of the proxy class or inherited
+         *               from its superinterface directly or indirectly
+         * @param args   the parameters used for the method invocation; can be {@code null}
+         *               if the number of formal parameters required by the method is zero.
+         * @return the value returned from the method invocation
+         * @throws IllegalArgumentException  if any of the following conditions is {@code true}:
+         *                                   <ul>
+         *                                   <li>{@code proxy} is not {@linkplain Proxy#isProxyClass(Class)
+         *                                       a proxy instance}; or</li>
+         *                                   <li>the given {@code method} is not a default method declared
+         *                                       in a proxy interface of the proxy class and not inherited from
+         *                                       any of its superinterfaces; or</li>
+         *                                   <li>the given {@code method} is overridden directly or indirectly by
+         *                                       the proxy interfaces and the method reference to the named
+         *                                       method never resolves to the given {@code method}; or</li>
+         *                                   <li>the length of the given {@code args} array does not match the
+         *                                       number of parameters of the method to be invoked; or</li>
+         *                                   <li>any of the {@code args} elements fails the unboxing
+         *                                       conversion if the corresponding method parameter type is
+         *                                       a primitive type; or if, after possible unboxing, any of the
+         *                                       {@code args} elements cannot be assigned to the corresponding
+         *                                       method parameter type.</li>
+         *                                   </ul>
+         * @throws InvocationTargetException if the invoked default method throws
+         *                                   any exception, it is wrapped by {@code InvocationTargetException}
+         *                                   and rethrown
+         * @throws NullPointerException      if {@code proxy} or {@code method} is
+         *                                   {@code null}
+         * @jvms 5.4.3. Method Resolution
+         */
+        Object invokeSuper(Object proxy, Method method, Object... args) throws InvocationTargetException;
+    }
+}

--- a/src/java.base/share/classes/java/lang/reflect/Proxy.java
+++ b/src/java.base/share/classes/java/lang/reflect/Proxy.java
@@ -29,6 +29,7 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.invoke.MethodType;
+import java.lang.invoke.WrongMethodTypeException;
 import java.lang.module.ModuleDescriptor;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -46,6 +47,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BooleanSupplier;
 
 import jdk.internal.access.JavaLangAccess;
 import jdk.internal.access.SharedSecrets;
@@ -54,11 +56,11 @@ import jdk.internal.misc.VM;
 import jdk.internal.reflect.CallerSensitive;
 import jdk.internal.reflect.Reflection;
 import jdk.internal.loader.ClassLoaderValue;
-import jdk.internal.vm.annotation.Stable;
 import sun.reflect.misc.ReflectUtil;
 import sun.security.action.GetPropertyAction;
 import sun.security.util.SecurityConstants;
 
+import static java.lang.invoke.MethodType.methodType;
 import static java.lang.module.ModuleDescriptor.Modifier.SYNTHETIC;
 
 /**
@@ -151,9 +153,11 @@ import static java.lang.module.ModuleDescriptor.Modifier.SYNTHETIC;
  *
  * <li>A proxy interface may define a default method or inherit
  * a default method from its superinterface directly or indirectly.
- * An invocation handler can invoke a default method of a proxy interface
- * by calling {@link InvocationHandler#invokeDefaultMethod(Object, Method, Object...)
- * InvocationHandler::invokeDefaultMethod}.
+ * An invocation handler implementing:
+ * {@linkplain InvocationHandler2#invoke(InvocationHandler2.SuperInvoker, Object, Method, Object[])}
+ * can invoke a default method of a proxy interface by calling
+ * {@link InvocationHandler2.SuperInvoker#invokeSuper(Object, Method, Object...)}
+ * on the passed-in {@code SuperInvoker}.
  *
  * <li>An invocation of the {@code hashCode},
  * {@code equals}, or {@code toString} methods declared in
@@ -174,8 +178,9 @@ import static java.lang.module.ModuleDescriptor.Modifier.SYNTHETIC;
  * the accessibility of the proxy class is in line with the accessibility of
  * the proxy interfaces. Specifically, the package and the module membership
  * of a proxy class defined via the
- * {@link Proxy#getProxyClass(ClassLoader, Class[])} or
- * {@link Proxy#newProxyInstance(ClassLoader, Class[], InvocationHandler)}
+ * {@link Proxy#getProxyClass(ClassLoader, Class[])},
+ * {@link Proxy#newProxyInstance(ClassLoader, Class[], InvocationHandler)} or
+ * {@link Proxy#newProxyInstance(ClassLoader, Class[], InvocationHandler2)}
  * methods is specified as follows:
  *
  * <ol>
@@ -298,7 +303,7 @@ public class Proxy implements java.io.Serializable {
 
     /** parameter types of a proxy class constructor */
     private static final Class<?>[] constructorParams =
-        { InvocationHandler.class };
+        {InvocationHandler2.class, Object.class };
 
     /**
      * a cache of proxy constructors with
@@ -312,13 +317,7 @@ public class Proxy implements java.io.Serializable {
      * @serial
      */
     @SuppressWarnings("serial") // Not statically typed as Serializable
-    protected InvocationHandler h;
-
-    /**
-     * Prohibits instantiation.
-     */
-    private Proxy() {
-    }
+    protected InvocationHandler2 h;
 
     /**
      * Constructs a new {@code Proxy} instance from a subclass
@@ -329,10 +328,41 @@ public class Proxy implements java.io.Serializable {
      *
      * @throws NullPointerException if the given invocation handler, {@code h},
      *         is {@code null}.
+     * @throws IllegalArgumentException if the given invocation handler, {@code h},
+     *         overrides method
+     *         {@linkplain InvocationHandler2#invoke(InvocationHandler2.SuperInvoker, Object, Method, Object[])}
      */
     protected Proxy(InvocationHandler h) {
-        Objects.requireNonNull(h);
+        if (!PLAIN_HANDLER_CACHE.get(h.getClass())) {
+            throw new IllegalArgumentException("Can only use plain InvocationHandler");
+        }
         this.h = h;
+    }
+
+    /**
+     * Constructs a new {@code Proxy} instance from a subclass
+     * (typically, a dynamic proxy class) with the specified value
+     * for its invocation handler and a special instance of {@code trustHandle}
+     * object that can only be provided by trusted code.
+     *
+     * @param  h the invocation handler for this proxy instance
+     *
+     * @param trustHandle special instance of Object that can only be provided
+     *                   by trusted code
+     *
+     * @throws NullPointerException if the given invocation handler, {@code h},
+     *         is {@code null}.
+     *
+     * @throws IllegalArgumentException if given {@code trustHandle} is not a
+     *         special Object instance that can only be provided by trusted code.
+     *
+     * @since 16
+     */
+    protected Proxy(InvocationHandler2 h, Object trustHandle) {
+        if (trustHandle != TRUST_HANDLE) {
+            throw new IllegalArgumentException("Wrong 'trustHandle'");
+        }
+        this.h = Objects.requireNonNull(h);
     }
 
     /**
@@ -389,11 +419,7 @@ public class Proxy implements java.io.Serializable {
                                          Class<?>... interfaces)
         throws IllegalArgumentException
     {
-        Class<?> caller = System.getSecurityManager() == null
-                              ? null
-                              : Reflection.getCallerClass();
-
-        return getProxyConstructor(caller, loader, interfaces)
+        return getProxyConstructor(Reflection.getCallerClass(), loader, interfaces)
             .getDeclaringClass();
     }
 
@@ -403,9 +429,7 @@ public class Proxy implements java.io.Serializable {
      * and an array of interfaces. The returned constructor will have the
      * {@link Constructor#setAccessible(boolean) accessible} flag already set.
      *
-     * @param   caller passed from a public-facing @CallerSensitive method if
-     *                 SecurityManager is set or {@code null} if there's no
-     *                 SecurityManager
+     * @param   caller passed from a public-facing @CallerSensitive method
      * @param   loader the class loader to define the proxy class
      * @param   interfaces the list of interfaces for the proxy class
      *          to implement
@@ -419,9 +443,7 @@ public class Proxy implements java.io.Serializable {
         // optimization for single interface
         if (interfaces.length == 1) {
             Class<?> intf = interfaces[0];
-            if (caller != null) {
-                checkProxyAccess(caller, loader, intf);
-            }
+            checkProxyAccess(caller, loader, intf);
             return proxyCache.sub(intf).computeIfAbsent(
                 loader,
                 (ld, clv) -> new ProxyBuilder(ld, clv.key()).build()
@@ -429,9 +451,7 @@ public class Proxy implements java.io.Serializable {
         } else {
             // interfaces cloned
             final Class<?>[] intfsArray = interfaces.clone();
-            if (caller != null) {
-                checkProxyAccess(caller, loader, intfsArray);
-            }
+            checkProxyAccess(caller, loader, intfsArray);
             final List<Class<?>> intfs = Arrays.asList(intfsArray);
             return proxyCache.sub(intfs).computeIfAbsent(
                 loader,
@@ -918,6 +938,209 @@ public class Proxy implements java.io.Serializable {
     }
 
     /**
+     * Implementation of {@linkplain java.lang.reflect.InvocationHandler2.SuperInvoker}
+     * interface dispatching to super default methods of proxy interfaces.
+     */
+    private static final class SuperInvokerImpl implements InvocationHandler2.SuperInvoker {
+        private static final Object[] EMPTY_ARGS = new Object[0];
+        private final ConcurrentHashMap<Method, MethodHandle> methods = new ConcurrentHashMap<>();
+        private final Lookup proxyLookup;
+
+        private SuperInvokerImpl(Lookup proxyLookup) {
+            this.proxyLookup = proxyLookup;
+        }
+
+        @Override
+        public Object invokeSuper(Object proxy, Method method, Object... args) throws InvocationTargetException {
+            // verify that the object is actually an instance of the correct proxy class
+            if (proxy.getClass() != proxyLookup.lookupClass()) {
+                throw new IllegalArgumentException("'proxy' is not an instance of " + proxyLookup.lookupClass());
+            }
+            // ...that the method is a default method...
+            if (!method.isDefault()) {
+                throw new IllegalArgumentException("\"" + method + "\" is not a default method");
+            }
+
+            MethodHandle superMH = getSuperMH(method);
+
+            // the args array can be null if the number of formal parameters required by
+            // the method is zero (consistent with Method::invoke)
+            Object[] params = args != null ? args : EMPTY_ARGS;
+
+            // invoke the super method
+            try {
+                return superMH.invokeExact(proxy, params);
+            } catch (ClassCastException | NullPointerException e) {
+                throw new IllegalArgumentException(e.getMessage(), e);
+            } catch (InvocationTargetException | RuntimeException | Error e) {
+                throw e;
+            } catch (Throwable e) {
+                // should not reach here
+                throw new InternalError(e);
+            }
+        }
+
+        /**
+         * Looks up special method handle, transforms and caches it.
+         *
+         * @param method the super method to lookup
+         * @return transformed special method handle of super method.
+         */
+        private MethodHandle getSuperMH(Method method) {
+            MethodHandle superMH = methods.get(method);
+            if (superMH == null) {
+                Class<?> proxyClass = proxyLookup.lookupClass();
+                MethodType type = methodType(method.getReturnType(), method.getParameterTypes());
+                Class<?> proxyInterface = findProxyInterfaceOrElseThrow(proxyClass, method);
+                MethodHandle dmh;
+                try {
+                    dmh = proxyLookup
+                        .findSpecial(proxyInterface, method.getName(), type, proxyClass)
+                        .withVarargs(false);
+                } catch (IllegalAccessException | NoSuchMethodException e) {
+                    // should not reach here
+                    throw new InternalError(e);
+                }
+                // this check can be turned into assertion as it is guaranteed to succeed by the virtue of
+                // looking up a default (instance) method declared or inherited by proxyInterface
+                // while proxyClass implements (is a subtype of) proxyInterface ...
+                assert ((BooleanSupplier) () -> {
+                    try {
+                        // make sure that the method type matches
+                        dmh.asType(type.insertParameterTypes(0, proxyClass));
+                        return true;
+                    } catch (WrongMethodTypeException e) {
+                        return false;
+                    }
+                }).getAsBoolean() : "Wrong method type";
+                // change return type to Object
+                MethodHandle mh = dmh.asType(dmh.type().changeReturnType(Object.class));
+                // wrap any exception thrown with InvocationTargetException
+                mh = MethodHandles.catchException(mh, Throwable.class, wrapWithInvocationTargetExceptionMH);
+                // spread array of arguments among parameters (skipping 1st parameter - target)
+                mh = mh.asSpreader(1, Object[].class, type.parameterCount());
+                // change target type to Object
+                mh = mh.asType(methodType(Object.class, Object.class, Object[].class));
+
+                // push MH into cache
+                MethodHandle cached = methods.putIfAbsent(method, mh);
+                if (cached != null) {
+                    superMH = cached;
+                } else {
+                    superMH = mh;
+                }
+            }
+            return superMH;
+        }
+
+
+        /**
+         * Finds the first proxy interface that declares the given method
+         * directly or indirectly.
+         *
+         * @throws IllegalArgumentException if not found
+         */
+        private static Class<?> findProxyInterfaceOrElseThrow(Class<?> proxyClass, Method method) {
+            Class<?> declaringClass = method.getDeclaringClass();
+            if (!declaringClass.isInterface()) {
+                throw new IllegalArgumentException("\"" + method +
+                                                   "\" is not a method declared in the proxy class");
+            }
+
+            List<Class<?>> proxyInterfaces = Arrays.asList(proxyClass.getInterfaces());
+            // the method's declaring class is a proxy interface
+            if (proxyInterfaces.contains(declaringClass))
+                return declaringClass;
+
+            Deque<Class<?>> deque = new ArrayDeque<>();
+            Set<Class<?>> visited = new HashSet<>();
+            boolean indirectMethodRef = false;
+            for (Class<?> intf : proxyInterfaces) {
+                assert intf != declaringClass;
+                visited.add(intf);
+                deque.add(intf);
+
+                Class<?> c;
+                while ((c = deque.poll()) != null) {
+                    if (c == declaringClass) {
+                        try {
+                            // check if this method is the resolved method if referenced from
+                            // this proxy interface (i.e. this method is not implemented
+                            // by any other superinterface)
+                            Method m = intf.getMethod(method.getName(), method.getParameterTypes());
+                            if (m.getDeclaringClass() == declaringClass) {
+                                return intf;
+                            }
+                            indirectMethodRef = true;
+                        } catch (NoSuchMethodException e) {}
+
+                        // skip traversing its superinterfaces
+                        // another proxy interface may extend it and so
+                        // the method's declaring class is left unvisited.
+                        continue;
+                    }
+                    // visit all superinteraces of one proxy interface to find if
+                    // this proxy interface inherits the method directly or indirectly
+                    visited.add(c);
+                    for (Class<?> superIntf : c.getInterfaces()) {
+                        if (!visited.contains(superIntf) && !deque.contains(superIntf)) {
+                            if (superIntf == declaringClass) {
+                                deque.addFirst(superIntf);
+                            } else {
+                                deque.add(superIntf);
+                            }
+                        }
+                    }
+                }
+            }
+
+            throw new IllegalArgumentException(
+                "\"" + method +
+                (indirectMethodRef
+                 ? "\" is overridden directly or indirectly by the proxy interfaces"
+                 : "\" is not a method declared in the proxy class")
+            );
+        }
+
+        /**
+         * Wraps given cause with InvocationTargetException and throws it.
+         *
+         * @throws InvocationTargetException wrapping given cause
+         */
+        private static Object wrapWithInvocationTargetException(Throwable cause) throws InvocationTargetException {
+            throw new InvocationTargetException(cause, cause.toString());
+        }
+
+        private static final MethodHandle wrapWithInvocationTargetExceptionMH;
+
+        static {
+            try {
+                wrapWithInvocationTargetExceptionMH = MethodHandles.lookup().findStatic(
+                    SuperInvokerImpl.class,
+                    "wrapWithInvocationTargetException",
+                    methodType(Object.class, Throwable.class)
+                );
+            } catch (NoSuchMethodException | IllegalAccessException e) {
+                throw new InternalError(e);
+            }
+        }
+    } // end of SuperInvokerImpl
+
+    /**
+     * Factory method creating {@linkplain java.lang.reflect.InvocationHandler2.SuperInvoker}
+     * implementation. This method is called from static initializer of a dynamic
+     * proxy class.
+     *
+     * @param proxyLookup the full-privilege Lookup of dynamic proxy class.
+     * @return an instance of {@linkplain java.lang.reflect.InvocationHandler2.SuperInvoker}
+     *         which can be used to invoke super default methods of proxy interfaces.
+     * @since 16
+     */
+    protected static InvocationHandler2.SuperInvoker newSuperInvoker(Lookup proxyLookup) {
+        return new SuperInvokerImpl(proxyLookup);
+    }
+
+    /**
      * Returns a proxy instance for the specified interfaces
      * that dispatches method invocations to the specified invocation
      * handler.
@@ -1009,6 +1232,7 @@ public class Proxy implements java.io.Serializable {
      *          {@code null}
      *
      * @see <a href="#membership">Package and Module Membership of Proxy Class</a>
+     * @see #newProxyInstance(ClassLoader, Class[], InvocationHandler2)
      * @revised 9
      * @spec JPMS
      */
@@ -1018,9 +1242,52 @@ public class Proxy implements java.io.Serializable {
                                           InvocationHandler h) {
         Objects.requireNonNull(h);
 
-        final Class<?> caller = System.getSecurityManager() == null
-                                    ? null
-                                    : Reflection.getCallerClass();
+        final Class<?> caller = Reflection.getCallerClass();
+
+        /*
+         * Look up or generate the designated proxy class and its constructor.
+         */
+        Constructor<?> cons = getProxyConstructor(caller, loader, interfaces);
+
+        try {
+            return newProxyInstance(caller, cons, h);
+        } catch (IllegalAccessException e) {
+            throw new IllegalArgumentException(
+                "InvocationHandler is not plain and interfaces are not accessible",
+                e
+            );
+        }
+    }
+
+    /**
+     * Overloaded {@linkplain #newProxyInstance(ClassLoader, Class[], InvocationHandler)}
+     * method taking a {@linkplain InvocationHandler2} instead of plain
+     * {@linkplain InvocationHandler} parameter which allows passing lambdas
+     * taking additional {@linkplain java.lang.reflect.InvocationHandler2.SuperInvoker}
+     * argument.
+     *
+     * @param   loader the class loader to define the proxy class
+     * @param   interfaces the list of interfaces for the proxy class
+     *          to implement
+     * @param   h the invocation handler to dispatch method invocations to
+     * @return  a proxy instance with the specified invocation handler of a
+     *          proxy class that is defined by the specified class loader
+     *          and that implements the specified interfaces
+     * @throws IllegalAccessException if given InvocationHandler is not plain and
+     *                                any of given interfaces is not accessible to
+     *                                the caller of this method
+     * @see #newProxyInstance(ClassLoader, Class[], InvocationHandler)
+     * @since 16
+     */
+    @CallerSensitive
+    public static Object newProxyInstance(ClassLoader loader,
+                                          Class<?>[] interfaces,
+                                          InvocationHandler2 h)
+        throws IllegalAccessException
+    {
+        Objects.requireNonNull(h);
+
+        final Class<?> caller = Reflection.getCallerClass();
 
         /*
          * Look up or generate the designated proxy class and its constructor.
@@ -1030,18 +1297,36 @@ public class Proxy implements java.io.Serializable {
         return newProxyInstance(caller, cons, h);
     }
 
-    private static Object newProxyInstance(Class<?> caller, // null if no SecurityManager
+    private static Object newProxyInstance(Class<?> caller,
                                            Constructor<?> cons,
-                                           InvocationHandler h) {
+                                           InvocationHandler2 h)
+        throws IllegalAccessException
+    {
+        if (!PLAIN_HANDLER_CACHE.get(h.getClass())) {
+            // additional access checks are needed for non-plain handlers...
+            for (Class<?> intf : cons.getDeclaringClass().getInterfaces()) {
+                boolean isPublic = Modifier.isPublic(intf.getModifiers());
+                // same module?
+                if (intf.getModule().equals(caller.getModule())) {
+                    if (isPublic || intf.getPackageName().equals(caller.getPackageName())) continue;
+                } else {
+                    if (isPublic && intf.getModule().isExported(intf.getPackageName(), caller.getModule())) continue;
+                }
+                // else throw IAE
+                throw new IllegalAccessException(
+                    caller + " from module " + caller.getModule() +
+                    " has no access to " + intf + " in module " + intf.getModule()
+                );
+            }
+        }
+
         /*
          * Invoke its constructor with the designated invocation handler.
          */
         try {
-            if (caller != null) {
-                checkNewProxyPermission(caller, cons.getDeclaringClass());
-            }
+            checkNewProxyPermission(caller, cons.getDeclaringClass());
 
-            return cons.newInstance(new Object[]{h});
+            return cons.newInstance(h, TRUST_HANDLE);
         } catch (IllegalAccessException | InstantiationException e) {
             throw new InternalError(e.toString(), e);
         } catch (InvocationTargetException e) {
@@ -1101,18 +1386,22 @@ public class Proxy implements java.io.Serializable {
     }
 
     /**
-     * Returns the invocation handler for the specified proxy instance.
+     * Returns plain {@linkplain InvocationHandler} type of invocation handler
+     * for the specified proxy instance if it was initialized with such type of handler.
      *
      * @param   proxy the proxy instance to return the invocation handler for
      * @return  the invocation handler for the proxy instance
      * @throws  IllegalArgumentException if the argument is not a
-     *          proxy instance
+     *          proxy instance or if it is a proxy instance initialized with
+     *          invocation handler directly implementing
+     *          {@linkplain InvocationHandler2}
      * @throws  SecurityException if a security manager, <em>s</em>, is present
      *          and the caller's class loader is not the same as or an
      *          ancestor of the class loader for the invocation handler
      *          and invocation of {@link SecurityManager#checkPackageAccess
      *          s.checkPackageAccess()} denies access to the invocation
      *          handler's class.
+     * @see #getInvocationHandler2(Object)
      */
     @CallerSensitive
     public static InvocationHandler getInvocationHandler(Object proxy)
@@ -1126,7 +1415,53 @@ public class Proxy implements java.io.Serializable {
         }
 
         final Proxy p = (Proxy) proxy;
-        final InvocationHandler ih = p.h;
+        final InvocationHandler2 ih = p.h;
+        if (!(ih instanceof InvocationHandler)) {
+            throw new IllegalArgumentException("not a proxy instance with plain InvocationHandler");
+        }
+        if (System.getSecurityManager() != null) {
+            Class<?> ihClass = ih.getClass();
+            Class<?> caller = Reflection.getCallerClass();
+            if (ReflectUtil.needsPackageAccessCheck(caller.getClassLoader(),
+                                                    ihClass.getClassLoader()))
+            {
+                ReflectUtil.checkPackageAccess(ihClass);
+            }
+        }
+
+        return (InvocationHandler)ih;
+    }
+
+    /**
+     * Returns {@linkplain InvocationHandler2} type
+     * of invocation handler for the specified proxy instance.
+     *
+     * @param   proxy the proxy instance to return the invocation handler for
+     * @return  the invocation handler for the proxy instance
+     * @throws  IllegalArgumentException if the argument is not a
+     *          proxy instance
+     * @throws  SecurityException if a security manager, <em>s</em>, is present
+     *          and the caller's class loader is not the same as or an
+     *          ancestor of the class loader for the invocation handler
+     *          and invocation of {@link SecurityManager#checkPackageAccess
+     *          s.checkPackageAccess()} denies access to the invocation
+     *          handler's class.
+     * @since 16
+     * @see #getInvocationHandler(Object)
+     */
+    @CallerSensitive
+    public static InvocationHandler2 getInvocationHandler2(Object proxy)
+    throws IllegalArgumentException
+    {
+        /*
+         * Verify that the object is actually a proxy instance.
+         */
+        if (!isProxyClass(proxy.getClass())) {
+            throw new IllegalArgumentException("not a proxy instance");
+        }
+
+        final Proxy p = (Proxy) proxy;
+        final InvocationHandler2 ih = p.h;
         if (System.getSecurityManager() != null) {
             Class<?> ihClass = ih.getClass();
             Class<?> caller = Reflection.getCallerClass();
@@ -1143,134 +1478,32 @@ public class Proxy implements java.io.Serializable {
     private static final String PROXY_PACKAGE_PREFIX = ReflectUtil.PROXY_PACKAGE;
 
     /**
-     * A cache of Method -> MethodHandle for default methods.
+     * A special instance of Object passed to
+     * {@linkplain #Proxy(InvocationHandler2, Object)}
+     * constructor to prove it has been called from trusted code that has access
+     * to this field.
      */
-    private static final ClassValue<ConcurrentHashMap<Method, MethodHandle>>
-            DEFAULT_METHODS_MAP = new ClassValue<>() {
+    private static final Object TRUST_HANDLE = new Object();
+
+    /**
+     * A cache of flag discriminating plain handlers (implementing
+     * {@linkplain InvocationHandler} and not overriding
+     * {@linkplain InvocationHandler2#invoke(InvocationHandler2.SuperInvoker, Object, Method, Object[])} method)
+     * from handlers that override/implement the method).
+     */
+    private static final ClassValue<Boolean> PLAIN_HANDLER_CACHE = new ClassValue<>() {
         @Override
-        protected ConcurrentHashMap<Method, MethodHandle> computeValue(Class<?> type) {
-            return new ConcurrentHashMap<>(4);
+        protected Boolean computeValue(Class<?> type) {
+            assert InvocationHandler2.class.isAssignableFrom(type);
+            try {
+                Method m = type.getMethod(
+                    "invoke", InvocationHandler2.SuperInvoker.class,
+                    Object.class, Method.class, Object[].class
+                );
+                return m.getDeclaringClass() == InvocationHandler.class;
+            } catch (NoSuchMethodException e) {
+                throw (Error) new NoSuchMethodError(e.getMessage()).initCause(e);
+            }
         }
     };
-
-    static ConcurrentHashMap<Method, MethodHandle> defaultMethodMap(Class<?> proxyClass) {
-        assert isProxyClass(proxyClass);
-        return DEFAULT_METHODS_MAP.get(proxyClass);
-    }
-
-    static final Object[] EMPTY_ARGS = new Object[0];
-
-    /**
-     * Finds the first proxy interface that declares the given method
-     * directly or indirectly.
-     *
-     * @throws IllegalArgumentException if not found
-     */
-    static Class<?> findProxyInterfaceOrElseThrow(Class<?> proxyClass, Method method) {
-        Class<?> declaringClass = method.getDeclaringClass();
-        if (!declaringClass.isInterface()) {
-            throw new IllegalArgumentException("\"" + method +
-                    "\" is not a method declared in the proxy class");
-        }
-
-        List<Class<?>> proxyInterfaces = Arrays.asList(proxyClass.getInterfaces());
-        // the method's declaring class is a proxy interface
-        if (proxyInterfaces.contains(declaringClass))
-            return declaringClass;
-
-        Deque<Class<?>> deque = new ArrayDeque<>();
-        Set<Class<?>> visited = new HashSet<>();
-        boolean indirectMethodRef = false;
-        for (Class<?> intf : proxyInterfaces) {
-            assert intf != declaringClass;
-            visited.add(intf);
-            deque.add(intf);
-
-            Class<?> c;
-            while ((c = deque.poll()) != null) {
-                if (c == declaringClass) {
-                    try {
-                        // check if this method is the resolved method if referenced from
-                        // this proxy interface (i.e. this method is not implemented
-                        // by any other superinterface)
-                        Method m = intf.getMethod(method.getName(), method.getParameterTypes());
-                        if (m.getDeclaringClass() == declaringClass) {
-                            return intf;
-                        }
-                        indirectMethodRef = true;
-                    } catch (NoSuchMethodException e) {}
-
-                    // skip traversing its superinterfaces
-                    // another proxy interface may extend it and so
-                    // the method's declaring class is left unvisited.
-                    continue;
-                }
-                // visit all superinteraces of one proxy interface to find if
-                // this proxy interface inherits the method directly or indirectly
-                visited.add(c);
-                for (Class<?> superIntf : c.getInterfaces()) {
-                    if (!visited.contains(superIntf) && !deque.contains(superIntf)) {
-                        if (superIntf == declaringClass) {
-                            deque.addFirst(superIntf);
-                        } else {
-                            deque.add(superIntf);
-                        }
-                    }
-                }
-            }
-        }
-
-        throw new IllegalArgumentException("\"" + method + (indirectMethodRef
-                ? "\" is overridden directly or indirectly by the proxy interfaces"
-                : "\" is not a method declared in the proxy class"));
-    }
-
-    /**
-     * Returns a Lookup object for the lookup class which is the class of this
-     * proxy instance.
-     *
-     * @return a lookup for proxy class of this proxy instance
-     */
-    static Lookup proxyClassLookup(Lookup caller, Class<?> proxyClass) {
-        return AccessController.doPrivileged(new PrivilegedAction<>() {
-            @Override
-            public Lookup run() {
-                try {
-                    Method m = proxyClass.getDeclaredMethod("proxyClassLookup", Lookup.class);
-                    m.setAccessible(true);
-                    return (Lookup) m.invoke(null, caller);
-                } catch (ReflectiveOperationException e) {
-                    throw new InternalError(e);
-                }
-            }
-        });
-    }
-
-    /**
-     * Wraps given cause with InvocationTargetException and throws it.
-     *
-     * @throws InvocationTargetException wrapping given cause
-     */
-    private static Object wrapWithInvocationTargetException(Throwable cause) throws InvocationTargetException {
-        throw new InvocationTargetException(cause, cause.toString());
-    }
-
-    @Stable
-    private static MethodHandle wrapWithInvocationTargetExceptionMH;
-
-    static MethodHandle wrapWithInvocationTargetExceptionMH() {
-        MethodHandle mh = wrapWithInvocationTargetExceptionMH;
-        if (mh == null) {
-            try {
-                wrapWithInvocationTargetExceptionMH = mh = MethodHandles.lookup().findStatic(
-                    Proxy.class,
-                    "wrapWithInvocationTargetException",
-                    MethodType.methodType(Object.class, Throwable.class)
-                );
-            } catch (NoSuchMethodException | IllegalAccessException e) {
-                throw new InternalError(e);
-            }
-        }
-        return mh;
-    }
 }

--- a/test/jdk/java/lang/reflect/Proxy/nonPublicProxy/DefaultMethodProxy.java
+++ b/test/jdk/java/lang/reflect/Proxy/nonPublicProxy/DefaultMethodProxy.java
@@ -24,50 +24,46 @@
 import java.lang.reflect.*;
 import java.util.Arrays;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import static org.testng.Assert.*;
+import p.PProxyMaker;
 
 /*
  * @test
  * @bug 8159746
  * @summary Test invoking a default method in a non-public proxy interface
- * @build p.Foo p.Bar p.DefaultMethodInvoker
+ * @build p.Foo p.Bar p.PProxyMaker
  * @run testng DefaultMethodProxy
  */
 public class DefaultMethodProxy {
-    public interface I {
-        default String m() { return "I"; }
+
+    public interface Baz {
+        default String baz() { return "baz"; }
     }
 
-    @Test
-    public static void hasPackageAccess() throws Exception {
-        Class<?> fooClass = Class.forName("p.Foo");
-        Class<?> barClass = Class.forName("p.Bar");
-
-        // create a proxy instance of a non-public proxy interface
-        makeProxy(IH, fooClass).testDefaultMethod("foo");
-        makeProxy(IH, barClass, fooClass).testDefaultMethod("bar");
-
-        // create a proxy instance of a public proxy interface should succeed
-        makeProxy(IH, I.class).testDefaultMethod("I");
-    }
-
-    @DataProvider(name = "nonPublicIntfs")
-    private static Object[][] nonPublicIntfs() throws ClassNotFoundException {
+    @DataProvider(name = "inaccessibleIntfcs")
+    private static Object[][] inaccessibleIntfcs() throws ClassNotFoundException {
         Class<?> fooClass = Class.forName("p.Foo");
         Class<?> barClass = Class.forName("p.Bar");
         return new Object[][]{
                 new Object[]{new Class<?>[]{ fooClass }},
                 new Object[]{new Class<?>[]{ barClass }},
-                new Object[]{new Class<?>[]{ barClass, fooClass }},
+                // throwing an accessible interface to the mix does not change things
+                new Object[]{new Class<?>[]{ fooClass, Baz.class }},
+                new Object[]{new Class<?>[]{ barClass, Baz.class }},
         };
     }
 
-    @Test(dataProvider = "nonPublicIntfs")
-    public static void noPackageAccess(Class<?>[] intfs) throws Exception {
-        makeProxy(IH_NO_ACCESS, intfs).testDefaultMethod("dummy");
+    @Test(dataProvider = "inaccessibleIntfcs")
+    public static void hasPackageAccess(Class<?>[] intfs) throws ReflectiveOperationException {
+        new DefaultMethodProxy(PProxyMaker.makeProxy(IH, intfs)).testDefaultMethod("foo", "bar");
+    }
+
+    @Test(dataProvider = "inaccessibleIntfcs", expectedExceptions = IllegalAccessException.class)
+    public static void noPackageAccess(Class<?>[] intfs) throws IllegalAccessException {
+        makeProxy(IH, intfs);
     }
 
     final Object proxy;
@@ -78,47 +74,30 @@ public class DefaultMethodProxy {
     /*
      * Verify if a default method "m" can be invoked successfully
      */
-    void testDefaultMethod(String expected) throws ReflectiveOperationException {
+    void testDefaultMethod(String ... expected) throws ReflectiveOperationException {
         Method m = proxy.getClass().getDeclaredMethod("m");
         m.setAccessible(true);
         String name = (String)m.invoke(proxy);
-        if (!expected.equals(name)) {
-            throw new RuntimeException("return value: " + name + " expected: " + expected);
+        if (Stream.of(expected).noneMatch(name::equals)) {
+            throw new RuntimeException("return value: " + name + " expected one of: " + Arrays.toString(expected));
         }
     }
 
     // invocation handler with access to the non-public interface in package p
-    private static final InvocationHandler IH = (proxy, method, params) -> {
+    private static final InvocationHandler2 IH = (superInvoker, proxy, method, params) -> {
         System.out.format("Proxy for %s: invoking %s%n",
                 Arrays.stream(proxy.getClass().getInterfaces())
                       .map(Class::getName)
                       .collect(Collectors.joining(", ")), method.getName());
         if (method.isDefault()) {
-            return p.DefaultMethodInvoker.invoke(proxy, method, params);
+            return superInvoker.invokeSuper(proxy, method, params);
         }
         throw new UnsupportedOperationException(method.toString());
     };
 
-    // invocation handler with no access to the non-public interface in package p
+    // proxy maker with no access to the non-public interface in package p
     // expect IllegalAccessException thrown
-    private static final InvocationHandler IH_NO_ACCESS = (proxy, method, params) -> {
-        System.out.format("Proxy for %s: invoking %s%n",
-                Arrays.stream(proxy.getClass().getInterfaces())
-                        .map(Class::getName)
-                        .collect(Collectors.joining(", ")), method.getName());
-        if (method.isDefault()) {
-            try {
-                InvocationHandler.invokeDefaultMethod(proxy, method, params);
-                throw new RuntimeException("IAE not thrown in invoking: " + method);
-            } catch (IllegalAccessException e) {
-                return "dummy";
-            }
-        }
-        throw new UnsupportedOperationException(method.toString());
-    };
-
-    private static DefaultMethodProxy makeProxy(InvocationHandler ih, Class<?>... intfs) {
-        Object proxy = Proxy.newProxyInstance(DefaultMethodProxy.class.getClassLoader(), intfs, ih);
-        return new DefaultMethodProxy(proxy);
+    private static Object makeProxy(InvocationHandler2 ih, Class<?>... intfs) throws IllegalAccessException {
+        return Proxy.newProxyInstance(DefaultMethodProxy.class.getClassLoader(), intfs, ih);
     }
 }

--- a/test/jdk/java/lang/reflect/Proxy/nonPublicProxy/p/PProxyMaker.java
+++ b/test/jdk/java/lang/reflect/Proxy/nonPublicProxy/p/PProxyMaker.java
@@ -24,9 +24,9 @@
 package p;
 import java.lang.reflect.*;
 
-public class DefaultMethodInvoker {
-     public static Object invoke(Object proxy, Method method, Object... args)
-            throws IllegalAccessException, InvocationTargetException {
-         return InvocationHandler.invokeDefaultMethod(proxy, method, args);
-     }
+public class PProxyMaker {
+    // proxy maker with access to the non-public interfaces in package p
+    public static Object makeProxy(InvocationHandler2 ih, Class<?>... intfs) throws IllegalAccessException {
+       return Proxy.newProxyInstance(PProxyMaker.class.getClassLoader(), intfs, ih);
+    }
 }

--- a/test/jdk/java/lang/reflect/Proxy/src/test/jdk/test/DefaultMethods.java
+++ b/test/jdk/java/lang/reflect/Proxy/src/test/jdk/test/DefaultMethods.java
@@ -23,11 +23,9 @@
 
 package jdk.test;
 
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.InvocationHandler2;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
-import java.lang.reflect.UndeclaredThrowableException;
 
 /**
  * Tests invocation of default methods in exported types and inaccessible types
@@ -35,9 +33,7 @@ import java.lang.reflect.UndeclaredThrowableException;
  */
 public class DefaultMethods {
     private final static Module TEST_MODULE = DefaultMethods.class.getModule();
-    private final static InvocationHandler IH = (proxy, method, params) -> {
-        return InvocationHandler.invokeDefaultMethod(proxy, method, params);
-    };
+    private final static InvocationHandler2 IH = InvocationHandler2.SuperInvoker::invokeSuper;
 
     public static void main(String... args) throws Exception {
         // exported types from m1
@@ -70,28 +66,9 @@ public class DefaultMethods {
     }
 
     static void inaccessibleDefaultMethod(Class<?> intf) throws Exception {
-        Object proxy = Proxy.newProxyInstance(TEST_MODULE.getClassLoader(), new Class<?>[] { intf }, IH);
-        if (!proxy.getClass().getModule().isNamed()) {
-            throw new RuntimeException(proxy.getClass() + " expected to be in a named module");
-        }
-        Method m = intf.getMethod("m");
         try {
-            InvocationHandler.invokeDefaultMethod(proxy, m, null);
-            throw new RuntimeException("IAE not thrown invoking: " + m);
+            Proxy.newProxyInstance(TEST_MODULE.getClassLoader(), new Class<?>[]{intf}, IH);
+            throw new RuntimeException("IAE not thrown creating proxy implementing " + intf);
         } catch (IllegalAccessException e) {}
-
-        if (m.trySetAccessible()) {
-            try {
-                m.invoke(proxy);
-                throw new RuntimeException("IAE not thrown invoking: " + m);
-            } catch (InvocationTargetException e) {
-                // IAE wrapped by InvocationHandler::invoke with UndeclaredThrowableException
-                // then wrapped by Method::invoke with InvocationTargetException
-                assert e.getCause() instanceof UndeclaredThrowableException;
-                Throwable cause = e.getCause().getCause();
-                if (!(cause instanceof IllegalAccessException))
-                    throw e;
-            }
-        }
     }
 }


### PR DESCRIPTION
Here's alternative API #2. Instead of Lookup object, the alternative InvocationHandler2 receives a special SuperInvoker callback through which the super default methods can be called.