### PR TITLE
Add support for the constructor for serialization

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/DirectMethodHandle.java
@@ -134,8 +134,10 @@ class DirectMethodHandle extends MethodHandle {
         return make(member.getDeclaringClass(), member);
     }
     private static DirectMethodHandle makeAllocator(MemberName ctor) {
+        return makeAllocator(ctor, ctor.getDeclaringClass());
+    }
+    static DirectMethodHandle makeAllocator(MemberName ctor, Class<?> instanceClass) {
         assert(ctor.isConstructor() && ctor.getName().equals("<init>"));
-        Class<?> instanceClass = ctor.getDeclaringClass();
         ctor = ctor.asConstructor();
         assert(ctor.isConstructor() && ctor.getReferenceKind() == REF_newInvokeSpecial) : ctor;
         MethodType mtype = ctor.getMethodType().changeReturnType(instanceClass);

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -1824,7 +1824,7 @@ abstract class MethodHandleImpl {
 
             @Override
             public MethodHandle unreflectConstructorForSerialization(Constructor<?> ctor,
-                    Class<?> instantiatedClass) throws IllegalAccessException {
+                    Class<?> instantiatedClass) throws ReflectiveOperationException {
                 return MethodHandles.unreflectConstructorForSerialization(ctor, instantiatedClass);
             }
 

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -1824,7 +1824,7 @@ abstract class MethodHandleImpl {
 
             @Override
             public MethodHandle unreflectConstructorForSerialization(Constructor<?> ctor,
-                    Class<?> instantiatedClass) throws ReflectiveOperationException {
+                    Class<?> instantiatedClass) throws IllegalAccessException {
                 return MethodHandles.unreflectConstructorForSerialization(ctor, instantiatedClass);
             }
 

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -1823,6 +1823,12 @@ abstract class MethodHandleImpl {
             }
 
             @Override
+            public MethodHandle unreflectConstructorForSerialization(Constructor<?> ctor,
+                    Class<?> instantiatedClass) throws IllegalAccessException {
+                return MethodHandles.unreflectConstructorForSerialization(ctor, instantiatedClass);
+            }
+
+            @Override
             public VarHandle filterValue(VarHandle target, MethodHandle filterToTarget, MethodHandle filterFromTarget) {
                 return VarHandles.filterValue(target, filterToTarget, filterFromTarget);
             }
@@ -1851,6 +1857,7 @@ abstract class MethodHandleImpl {
             public VarHandle insertCoordinates(VarHandle target, int pos, Object... values) {
                 return VarHandles.insertCoordinates(target, pos, values);
             }
+
         });
     }
 

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -185,7 +185,7 @@ public class MethodHandles {
         return Lookup.IMPL_LOOKUP.unreflectField(field, isSetter);
     }
 
-    static MethodHandle unreflectConstructorForSerialization(Constructor<?> ctor, Class<?> instantiatedClass) throws ReflectiveOperationException {
+    static MethodHandle unreflectConstructorForSerialization(Constructor<?> ctor, Class<?> instantiatedClass) throws IllegalAccessException {
         if (!ctor.getDeclaringClass().isAssignableFrom(instantiatedClass)) {
             throw newIllegalArgumentException("Constructed type is not assinable to", ctor, instantiatedClass);
         }

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -185,11 +185,11 @@ public class MethodHandles {
         return Lookup.IMPL_LOOKUP.unreflectField(field, isSetter);
     }
 
-    static MethodHandle unreflectConstructorForSerialization(Constructor<?> ctor, Class<?> instantiatedClass) {
+    static MethodHandle unreflectConstructorForSerialization(Constructor<?> ctor, Class<?> instantiatedClass) throws ReflectiveOperationException {
         if (!ctor.getDeclaringClass().isAssignableFrom(instantiatedClass)) {
             throw newIllegalArgumentException("Constructed type is not assinable to", ctor, instantiatedClass);
         }
-        MemberName mn = Lookup.IMPL_LOOKUP.resolveOrFail(REF_newInvokeSpecial, new MemberName(ctor));
+        MemberName mn = new MemberName(ctor);
         return DirectMethodHandle.makeAllocator(mn, instantiatedClass).setVarargs(mn);
     }
 

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -185,6 +185,14 @@ public class MethodHandles {
         return Lookup.IMPL_LOOKUP.unreflectField(field, isSetter);
     }
 
+    static MethodHandle unreflectConstructorForSerialization(Constructor<?> ctor, Class<?> instantiatedClass) {
+        if (!ctor.getDeclaringClass().isAssignableFrom(instantiatedClass)) {
+            throw newIllegalArgumentException("Constructed type is not assinable to", ctor, instantiatedClass);
+        }
+        MemberName mn = Lookup.IMPL_LOOKUP.resolveOrFail(REF_newInvokeSpecial, new MemberName(ctor));
+        return DirectMethodHandle.makeAllocator(mn, instantiatedClass).setVarargs(mn);
+    }
+
     /**
      * Returns a {@link Lookup lookup object} which is trusted minimally.
      * The lookup has the {@code UNCONDITIONAL} mode.

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangInvokeAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangInvokeAccess.java
@@ -139,7 +139,7 @@ public interface JavaLangInvokeAccess {
     MethodHandle unreflectMethod(Class<?> caller, Method method) throws IllegalAccessException;
     MethodHandle unreflectConstructor(Constructor<?> ctor) throws IllegalAccessException;
     MethodHandle unreflectField(Field field, boolean isSetter) throws IllegalAccessException;
-    MethodHandle unreflectConstructorForSerialization(Constructor<?> ctor, Class<?> instantiatedClass) throws ReflectiveOperationException;
+    MethodHandle unreflectConstructorForSerialization(Constructor<?> ctor, Class<?> instantiatedClass) throws IllegalAccessException;
 
 
 }

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangInvokeAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangInvokeAccess.java
@@ -139,6 +139,7 @@ public interface JavaLangInvokeAccess {
     MethodHandle unreflectMethod(Class<?> caller, Method method) throws IllegalAccessException;
     MethodHandle unreflectConstructor(Constructor<?> ctor) throws IllegalAccessException;
     MethodHandle unreflectField(Field field, boolean isSetter) throws IllegalAccessException;
+    MethodHandle unreflectConstructorForSerialization(Constructor<?> ctor, Class<?> instantiatedClass) throws IllegalAccessException;
 
 
 }

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangInvokeAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangInvokeAccess.java
@@ -139,7 +139,7 @@ public interface JavaLangInvokeAccess {
     MethodHandle unreflectMethod(Class<?> caller, Method method) throws IllegalAccessException;
     MethodHandle unreflectConstructor(Constructor<?> ctor) throws IllegalAccessException;
     MethodHandle unreflectField(Field field, boolean isSetter) throws IllegalAccessException;
-    MethodHandle unreflectConstructorForSerialization(Constructor<?> ctor, Class<?> instantiatedClass) throws IllegalAccessException;
+    MethodHandle unreflectConstructorForSerialization(Constructor<?> ctor, Class<?> instantiatedClass) throws ReflectiveOperationException;
 
 
 }

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodHandleAccessorFactory.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodHandleAccessorFactory.java
@@ -88,7 +88,7 @@ final class MethodHandleAccessorFactory {
             MethodHandle target = mh.asSpreader(Object[].class, paramCount)
                                     .asType(methodType(Object.class, Object[].class));
             return new DirectConstructorAccessorImpl(ctor, target);
-        } catch (ReflectiveOperationException e) {
+        } catch (IllegalAccessException e) {
             throw new InternalError(e);
         }
     }

--- a/src/java.base/share/classes/jdk/internal/reflect/MethodHandleAccessorFactory.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/MethodHandleAccessorFactory.java
@@ -88,7 +88,7 @@ final class MethodHandleAccessorFactory {
             MethodHandle target = mh.asSpreader(Object[].class, paramCount)
                                     .asType(methodType(Object.class, Object[].class));
             return new DirectConstructorAccessorImpl(ctor, target);
-        } catch (IllegalAccessException e) {
+        } catch (ReflectiveOperationException e) {
             throw new InternalError(e);
         }
     }

--- a/src/java.base/share/classes/jdk/internal/reflect/ReflectionFactory.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/ReflectionFactory.java
@@ -483,14 +483,18 @@ public class ReflectionFactory {
 
     private final Constructor<?> generateConstructor(Class<?> cl,
                                                      Constructor<?> constructorToCall) {
-
-
-        ConstructorAccessor acc = new MethodAccessorGenerator().
-            generateSerializationConstructor(cl,
+        final ConstructorAccessor acc;
+        if (useDirectMethodHandle) {
+            assert VM.isModuleSystemInited();
+            acc = MethodHandleAccessorFactory.newConstructorAccessorForSerialization(constructorToCall, cl);
+        } else {
+            acc = new MethodAccessorGenerator().
+                    generateSerializationConstructor(cl,
                                              constructorToCall.getParameterTypes(),
                                              constructorToCall.getExceptionTypes(),
                                              constructorToCall.getModifiers(),
                                              constructorToCall.getDeclaringClass());
+        }
         Constructor<?> c = newConstructor(constructorToCall.getDeclaringClass(),
                                           constructorToCall.getParameterTypes(),
                                           constructorToCall.getExceptionTypes(),


### PR DESCRIPTION
- The core is in java.lang.invoke.DirectMethodHandle.makeAllocator.
- The constructor accessor for serialization doesn't extend `SerializationConstructorAccessorImpl`.